### PR TITLE
fix np.int bug, update readme to working ex

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,44 +64,53 @@ The outputs are:
 Example implementation
 ```
 from augmentdata import data_augment
-
-l=[
-[1.0,2.0,1.0,0],
+ '''
+    x^2 + y^2 + z^2 < 15 => 0
+    x^2 + y^2 + z^2 >= 15 => 1
+    '''
+    l=[
+    
+    [1.0,2.0,1.0,0],
     [1,3,1,0],
     [2,1,1,0],
     [3,2,1,0],
     [3,1,1,0],
+
     [1,3,4,1],
     [1,4,3,1],
     [1,4,4,1],
+
     [2,3,3,1],
     [2,3,4,1],
     [2,4,3,1],
     [2,4,4,1],
+
     [3,2,2,1],
     [3,3,2,1],
     [3,3,2,1],
     [3,4,2,1],
 
     [4,3,1,1]
-]
+    ]
 
-l=np.array(l)
-print("Original Data:")
-print(l)
-X=l[:,:-1]
-y=l[:,-1]
+    l=np.array(l)
+    X=l[:,:-1]
+    y=l[:,-1]
+    print("X=",X.shape,"y=",y.shape)
+    print("Original Data:")
+    print(l)
+    print("************************************")
 
+    
+    knnor=KNNOR()
+    X_new,y_new,_,_=knnor.fit_resample(X,y)
+    y_new=y_new.reshape(-1,1)
+    print(X_new.shape,y_new.shape)
 
-
-knnor = data_augment.KNNOR()
-knnor=KNNOR()
-X_new,y_new=knnor.fit_resample(X,y)
-y_new=y_new.reshape(-1,1)
-
-print("KNNOR Data:")
-new_data=np.append(X_new, y_new, axis=1)
-print(new_data)
+    print("KNNOR Data:")
+    new_data=np.append(X_new, y_new, axis=1)
+    print(new_data)
+    print("************************************")
 ```
 Output
 ```

--- a/knnor/data_augment.py
+++ b/knnor/data_augment.py
@@ -240,8 +240,8 @@ class KNNOR:
         from math import factorial
         
         try:
-            window_size = np.abs(np.int(window_size))
-            order = np.abs(np.int(order))
+            window_size = np.abs(int(window_size))
+            order = np.abs(int(order))
         except ValueError:
             raise ValueError("window_size and order have to be of type int")
         if window_size % 2 != 1 or window_size < 1:


### PR DESCRIPTION
np.int is now deprecated as of 1.24.0. Read more [here](https://levelup.gitconnected.com/fix-attributeerror-module-numpy-has-no-attribute-float-d7d68c5a4971)

Copied in working example from data_augment.py to readme
